### PR TITLE
Check player exists before attempting to process

### DIFF
--- a/src/main/java/com/arcaniax/gobrush/listener/PlayerInteractListener.java
+++ b/src/main/java/com/arcaniax/gobrush/listener/PlayerInteractListener.java
@@ -35,6 +35,7 @@ import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.math.Vector3;
 import com.sk89q.worldedit.world.block.BlockState;
 import com.sk89q.worldedit.world.block.BlockTypes;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -99,6 +100,10 @@ public class PlayerInteractListener implements Listener {
             QueueHandler queue = Fawe.instance().getQueueHandler();
             queue.async(() -> {
                 synchronized (localSession) {
+                    if (Bukkit.getPlayer(event.getPlayer().getName()) == null) {
+                        // player probably logged out
+                        return;
+                    }
                     EditSession editsession = localSession.createEditSession(BukkitAdapter.adapt(event.getPlayer()));
                     try {
                         HashMap<Vector3, BlockState> blocksToSet = new HashMap<>();


### PR DESCRIPTION
An issue noticed is tasks can get queued up for a player. When the player logs out all the tasks fail immediately when a edit session is created. This can produce thousands of error lines to output on the main thread, causing main thread lag.

This is difficult to recreate, but hopefully will treat a symptom of main thread lag.